### PR TITLE
maven: force https url for the maven central repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,15 @@
 	<!-- Repositories -->
 	<repositories>
 		<repository>
+			<id>maven-central-repo</id>
+			<name>Central Maven Repository</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+			<layout>default</layout>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
 			<id>digi-repo</id>
 			<name>Digi Releases Repository</name>
 			<layout>default</layout>


### PR DESCRIPTION
Effective January 15, 2020, The Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.

See https://blog.sonatype.com/central-repository-moving-to-https and https://support.sonatype.com/hc/en-us/articles/360041287334

Signed-off-by: Tatiana Leon <tatiana.leon@digi.com>