### PR TITLE
hardware: add new versions to the supported hardware list

### DIFF
--- a/library/src/main/java/com/digi/xbee/api/models/HardwareVersionEnum.java
+++ b/library/src/main/java/com/digi/xbee/api/models/HardwareVersionEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019, Digi International Inc.
+ * Copyright 2017-2021, Digi International Inc.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -110,6 +110,16 @@ public enum HardwareVersionEnum {
 	CELLULAR_3_LTE_M_ATT_TELIT(0x4C, "XBee3 Cellular LTE-M AT&T (Telit)"),  // Never released
 	/** @since 1.3.0 */
 	CELLULAR_3_CAT1_LTE_VERIZON(0x4D, "XBee3 Cellular Cat 1 LTE Verizon");
+	/** @since 1.3.1 */
+	CELLULAR_3_LTE_M_TELIT(0x4E, "XBee 3 Cellular LTE-M/NB-IoT (Telit)");
+	/** @since 1.3.1 */
+	XBEE3_DM_LR(0x50, "XB3-DMLR");
+	/** @since 1.3.1 */
+	XBEE3_DM_LR_868(0x51, "XB3-DMLR868");
+	/** @since 1.3.1 */
+	XBEE3_RR(0x52, "XBee 3 Reduced RAM");
+	/** @since 1.3.1 */
+	S2C_P5(0x53, "S2C P5");
 	
 	// Variables
 	private final int value;

--- a/library/src/main/java/com/digi/xbee/api/models/XBeeProtocol.java
+++ b/library/src/main/java/com/digi/xbee/api/models/XBeeProtocol.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019, Digi International Inc.
+ * Copyright 2017-2021, Digi International Inc.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -245,10 +245,12 @@ public enum XBeeProtocol {
 		case CELLULAR_3_LTE_M_ATT:
 		case CELLULAR_3_LTE_M_ATT_TELIT:
 		case CELLULAR_3_CAT1_LTE_VERIZON:
+		case CELLULAR_3_LTE_M_TELIT:
 			return CELLULAR;
 		case XBEE3:
 		case XBEE3_SMT:
 		case XBEE3_TH:
+		case XBEE3_RR:
 			if (firmwareVersion.startsWith("2"))
 				return RAW_802_15_4;
 			else if (firmwareVersion.startsWith("3"))
@@ -257,6 +259,11 @@ public enum XBeeProtocol {
 				return ZIGBEE;
 		case XB8X:
 			return DIGI_MESH;
+		case XBEE3_DM_LR:
+		case XBEE3_DM_LR_868:
+			return DIGI_MESH;
+		case S2C_P5:
+			return ZIGBEE;
 		default:
 			return ZIGBEE;
 		}


### PR DESCRIPTION
- 0x4E: XBee 3 Cellular LTE-M/NB-IoT (Telit)
- 0x50: XB3-DMLR
- 0x51: XB3-DMLR868
- 0x52: XBee 3 Reduced RAM
- 0x53: S2C P5

https://onedigi.atlassian.net/browse/XBJAPI-535

Signed-off-by: Diego Escalona <diego.escalona@digi.com>